### PR TITLE
fix(playground): align Night Owl theme with website Prism rendering

### DIFF
--- a/src/scripts/repl-init.ts
+++ b/src/scripts/repl-init.ts
@@ -3,6 +3,23 @@ import { prettify } from "htmlfy";
 // TODO: https://github.com/brijeshb42/monaco-themes/issues/65
 import nightOwlTheme from "../../node_modules/monaco-themes/themes/Night Owl.json" with { type: "json" };
 
+// Token rule overrides applied on top of monaco-themes' Night Owl so the
+// playground matches the Prism "Night Owl" theme used on the wcc.dev website
+// (https://github.com/PrismJS/prism-themes/blob/master/themes/prism-night-owl.css).
+// Monaco rules are evaluated in order, so appending these makes them win over
+// the imported defaults for the same token scopes. See issue #23.
+const prismAlignedRules: monaco.editor.ITokenThemeRule[] = [
+  // Prism styles comments in italic; monaco-themes' Night Owl leaves them upright.
+  { token: "comment", foreground: "637777", fontStyle: "italic" },
+  { token: "comment.line.double-slash", foreground: "637777", fontStyle: "italic" },
+  // Prism uses a single green (rgb(173,219,103) = #addb67) for all .token.string,
+  // while monaco-themes' Night Owl uses peach (#ecc48d) for `string.quoted.*`.
+  // Align the JS/TS string scopes that the playground actually renders.
+  { token: "string.quoted", foreground: "addb67" },
+  { token: "string.quoted.double", foreground: "addb67" },
+  { token: "string.quoted.single", foreground: "addb67" },
+];
+
 const inputContainer = document.getElementById("input-content") as HTMLDivElement;
 const outputContainer = document.getElementById("output-content") as HTMLDivElement;
 const workerUrl = new URL("./repl.ts", import.meta.url);
@@ -61,6 +78,7 @@ monaco.editor.defineTheme("custom-theme", {
   ...nightOwlTheme,
   // have to specify `base` explicitly or else TS complains
   base: "vs-dark",
+  rules: [...nightOwlTheme.rules, ...prismAlignedRules],
 });
 
 const commonSettings = {


### PR DESCRIPTION
## 概要

playground (Monaco Editor) と wcc.dev website (Prism) の Night Owl 表示を揃えるため、`src/scripts/repl-init.ts` で読み込んでいる `monaco-themes/themes/Night Owl.json` の上に **2 種類の token-rule オーバーライド** を追加しました。

| 種別 | Prism Night Owl (現状の website) | monaco-themes Night Owl (現状の playground) | 本PR後 |
|---|---|---|---|
| `.token.comment` / コメント | `font-style: italic` | upright (italic 無し) | italic を付与 |
| `.token.string` / JS文字列 | `#addb67`(緑、全 string 一律) | `string.quoted.*` のみ `#ecc48d`(peach) | `#addb67` に統一 |

Monaco の token rules は順序評価で後勝ちなので、`nightOwlTheme.rules` の末尾に追記する形にしました。差分は `src/scripts/repl-init.ts` のみ・**+18 行 / -0 行**で済んでいます。

実装内容は [Prism Night Owl CSS](https://github.com/PrismJS/prism-themes/blob/master/themes/prism-night-owl.css) の以下と整合:

\`\`\`css
.token.comment, .token.prolog, .token.cdata {
    color: rgb(99, 119, 119);  /* = #637777 */
    font-style: italic;
}

.token.string, .token.url, .token.entity, ... {
    color: rgb(173, 219, 103);  /* = #addb67 */
}
\`\`\`

## 動作確認

1. \`npm ci\`
2. \`npm run lint\` → 0 warnings / 0 errors
3. \`npm run check\` (tsgo) → エラー無し
4. \`npx oxfmt --check src/scripts/repl-init.ts\` → \`All matched files use the correct format\`
5. \`npm run dev\` で \`http://localhost:1984/\` を開き、デフォルトコードスニペットを表示
6. 同じ Footer コンポーネントのコードを表示している [wcc.dev のトップページ](https://wcc.dev/) のコードブロック (Prism) と並べて比較し、文字列 (\`'open'\`、\`'wcc-footer'\`、\`'template'\` など) が **両者とも緑 (\`#addb67\`)** で render されること、コメントが両者とも italic で render されることを目視で確認

リポ全体には pre-existing な \`oxfmt --check\` 警告 (21 files) がありますが、本 PR の変更範囲外なので別 PR の方が無難と判断し触っていません。

Closes #23