### PR TITLE
feat: #11 support all language formats

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -62,12 +62,6 @@
     <div id="playground-container">
       <div id="input-container">
         <h2>Input</h2>
-        <select id="input-language">
-          <option value="js">JavaScript</option>
-          <option value="ts">TypeScript</option>
-          <option value="jsx">JSX</option>
-          <option value="tsx">TSX</option>
-        </select>
         <div id="input-content"></div>
       </div>
 

--- a/src/index.html
+++ b/src/index.html
@@ -62,6 +62,12 @@
     <div id="playground-container">
       <div id="input-container">
         <h2>Input</h2>
+        <select id="input-language">
+          <option value="js">JavaScript</option>
+          <option value="ts">TypeScript</option>
+          <option value="jsx">JSX</option>
+          <option value="tsx">TSX</option>
+        </select>
         <div id="input-content"></div>
       </div>
 

--- a/src/scripts/repl-init.ts
+++ b/src/scripts/repl-init.ts
@@ -54,7 +54,7 @@ class Footer extends HTMLElement {
 
 export default Footer;
 
-customElements.define('wcc-footer', Footer);
+customElements.define('x-footer', Footer);
 `;
 
 monaco.editor.defineTheme("custom-theme", {
@@ -72,12 +72,30 @@ const commonSettings = {
   theme: "custom-theme",
 };
 
-const extensionLanguageMapper = {
-  js: "javascript",
-  ts: "typescript",
-  jsx: "javascript",
-  tsx: "typescript",
-};
+// https://gist.github.com/RoboPhred/f767bea5cbc972e04155a625dc11da11
+// Important Bit #1: Typescript must see the 'file' it is editing as having a .tsx extension
+const modelUri = monaco.Uri.file("file.tsx");
+
+// Important Bit #2
+// By default, monaco use the "value" property to create its own model without any extensions, so typescript assumes ".ts"
+// We need to create a custom model using the desired file name (uri). See the last arg.
+const codeModel = monaco.editor.createModel(
+  inputContents.trim(),
+  "typescript",
+  modelUri, // Pass the file name to the model here.
+);
+
+// Important Bit #3: Tell typescript to use 'react' for jsx files.
+// TODO: support wc-compiler jsxImportSource
+monaco.typescript.typescriptDefaults.setCompilerOptions({
+  jsx: monaco.typescript.JsxEmit.Preserve,
+});
+
+// TODO: additional diagnostics
+monaco.typescript.typescriptDefaults.setDiagnosticsOptions({
+  noSemanticValidation: false,
+  noSyntaxValidation: false,
+});
 
 document.addEventListener("DOMContentLoaded", () => {
   console.log("Initializing Editor...");
@@ -85,9 +103,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   const inputEditor = monaco.editor.create(inputContainer, {
     value: inputContents.trim(),
-    language:
-      extensionLanguageMapper[languageSelector.value as keyof typeof extensionLanguageMapper] ??
-      "javascript",
+    language: "typescript",
     ...commonSettings,
   });
   const outputEditor = monaco.editor.create(outputContainer, {
@@ -96,12 +112,8 @@ document.addEventListener("DOMContentLoaded", () => {
     readOnly: true,
   });
 
-  languageSelector.addEventListener("change", () => {
-    const language =
-      extensionLanguageMapper[languageSelector.value as keyof typeof extensionLanguageMapper] ??
-      "javascript";
-    monaco.editor.setModelLanguage(inputEditor.getModel()!, language);
-  });
+  inputEditor.setModel(codeModel);
+  monaco.editor.setModelLanguage(inputEditor.getModel()!, "typescript");
 
   // listen for changes in the input editor and send the updated code to the worker for compilation
   inputEditor.onDidChangeModelContent(() => {

--- a/src/scripts/repl-init.ts
+++ b/src/scripts/repl-init.ts
@@ -72,12 +72,22 @@ const commonSettings = {
   theme: "custom-theme",
 };
 
+const extensionLanguageMapper = {
+  js: "javascript",
+  ts: "typescript",
+  jsx: "javascript",
+  tsx: "typescript",
+};
+
 document.addEventListener("DOMContentLoaded", () => {
   console.log("Initializing Editor...");
+  const languageSelector = document.getElementById("input-language") as HTMLSelectElement;
 
   const inputEditor = monaco.editor.create(inputContainer, {
     value: inputContents.trim(),
-    language: "javascript",
+    language:
+      extensionLanguageMapper[languageSelector.value as keyof typeof extensionLanguageMapper] ??
+      "javascript",
     ...commonSettings,
   });
   const outputEditor = monaco.editor.create(outputContainer, {
@@ -86,13 +96,26 @@ document.addEventListener("DOMContentLoaded", () => {
     readOnly: true,
   });
 
+  languageSelector.addEventListener("change", () => {
+    const language =
+      extensionLanguageMapper[languageSelector.value as keyof typeof extensionLanguageMapper] ??
+      "javascript";
+    monaco.editor.setModelLanguage(inputEditor.getModel()!, language);
+  });
+
   // listen for changes in the input editor and send the updated code to the worker for compilation
   inputEditor.onDidChangeModelContent(() => {
-    worker.postMessage([inputEditor.getValue()]);
+    worker.postMessage([inputEditor.getValue(), languageSelector.value ?? "javascript"]);
   });
 
   // once the worker sends back the compiled HTML, update the output editor with the result
   worker.onmessage = (result) => {
+    if (result.data.err) {
+      console.error("Error in worker:", result.data.err);
+      outputEditor.setValue(`Error: ${result.data.err.message || result.data.err}`);
+      return;
+    }
+
     outputEditor.setValue(prettify(result.data.output));
   };
 

--- a/src/scripts/repl.ts
+++ b/src/scripts/repl.ts
@@ -3,8 +3,11 @@ import { renderToString } from "wc-compiler";
 onmessage = async (e) => {
   console.log("Worker: Message received from main script", { e });
   const input = e.data[0];
-  const props = e.data[1] ?? null;
+  const language = e.data[1] ?? "javascript";
+  const props = e.data[2] ?? null;
   const wrappingEntryTag = true;
+
+  console.log({ input, language, props });
 
   let err;
   let output;


### PR DESCRIPTION
resolves #11 (also doing a little bit of #12 )

**TODO**
1. [x] IDE support
    - ~~typescript~~
    - ~~jsx~~
    - ~~tsx~~ - https://gist.github.com/RoboPhred/f767bea5cbc972e04155a625dc11da11
1. [ ] WCC support (needs a long term fix for [this patch](https://github.com/ProjectEvergreen/wcc/blob/master/patches/%40greenwood%2Bplugin-import-jsx%2B0.34.0-alpha.4.patch))
    - typescript
    - jsx
    - tsx
1. [ ] Signals
1. [x] ~~Input selector styling / output alignment~~ - N / A
1. [ ] (J|T)SX syntax highlighting? - https://www.npmjs.com/package/monaco-jsx-syntax-highlight
1. [ ] `jsxImportSource` for WCC
1. [ ] additional diagnostic / TS options (own issue with #14 )